### PR TITLE
fix: fix using WriteBinary but wbuf was reusing in endWrite

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -360,8 +360,12 @@ func (f *Framer) endWrite() error {
 	if f.logWrites {
 		f.logWrite()
 	}
-	_, err := f.w.WriteBinary(f.wbuf)
-	return err
+	destBuf, err := f.w.Malloc(len(f.wbuf))
+	if err != nil {
+		return err
+	}
+	copy(destBuf, f.wbuf)
+	return nil
 }
 
 func (f *Framer) logWrite() {


### PR DESCRIPTION
Frame 的 endWrite 中，wbuf 是复用的，不能使用 WriteBinary 来写（小于 4K 是没问题的），改用malloc + copy 的方式